### PR TITLE
Environment variable option for private repo url

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,5 +1,5 @@
 parameters:
-    recipe_repo_private: https://github.com/moay/demo-recipes
+    env(recipe_repo_private): https://github.com/moay/demo-recipes
 
     official_endpoint: https://symfony.sh/
     proxy_official_endpoint: true
@@ -22,7 +22,7 @@ services:
             $officialEndpoint: '%official_endpoint%'
             $enableProxy: '%proxy_official_endpoint%'
             $cacheEndpoint: '%cache_official_endpoint%'
-            $privateRepoUrl: '%recipe_repo_private%'
+            $privateRepoUrl: '%env(recipe_repo_private)%'
             $officialRepoUrl: '%recipe_repo_official%'
             $contribRepoUrl: '%recipe_repo_contrib%'
             $mirrorOfficialRepo: '%mirror_official_recipes%'

--- a/docs/topics/configuration.md
+++ b/docs/topics/configuration.md
@@ -2,7 +2,8 @@
 
 The server comes well configured but the configuration can be tweaked. You should set your private recipes repo, all other options are optional.
 
-In order to change the configuration, alter the file `/config/services.yaml`.
+In order to change the configuration alter the file `/config/services.yaml` or
+set your env variables.
 
 ### Private recipes repo
 
@@ -10,6 +11,9 @@ Your private recipes repo must be a git repo. It must be available via git, so i
 
     recipe_repo_private: The url to your private recipe repo
     
+You can set the parameter directly in `/config/services.yaml` or in the `.env`
+file or via an environment variable.
+
 The url provided must be a *https* url. Make sure to provide the right url structure, here are two examples:
 
 *  `https://github.com/moay/demo-recipes`

--- a/docs/topics/setup.md
+++ b/docs/topics/setup.md
@@ -4,8 +4,8 @@ Setting up the server should be quick and easy. These are the necessary steps:
 
 1. [Download](https://github.com/moay/symfony-flex-server/releases) the project from Github (or `git clone https://github.com/moay/symfony-flex-server`)
 2. Navigate to the project folder and run `composer install`.
-3. Open the file `config/services.yaml` and enter the url to your private recipes repo.
-4. Setup the `APP_ENV` properly. This can be done in the `.env` file (create if needed) or on the hosting. Setting it to `prod` is recommended.
+3. Setup the url to your private recipes repo: `recipe_repo_private`. Use the `.env` file, or an environment variable, or set it directly in `config/services.yaml`.
+4. Setup the `APP_ENV` properly. This can be done in the `.env` file as well or as an environment variable. Setting it to `prod` is recommended.
 5. Run `php bin/console recipes:initialize` in order to download your recipes.
 
 *Of course, you should deploy the project to where it will be hosted (probably before step 2).*


### PR DESCRIPTION
This PR is to let users configure `recipe_repo_private` via an environment variable.

This helps with containerisation of the service, e.g. `docker run --env recipe_repo_private=<url>`
