### PR TITLE
Fix wrong class use for Request object (closes #26)

### DIFF
--- a/src/Service/Decoder/ResponseDecoder.php
+++ b/src/Service/Decoder/ResponseDecoder.php
@@ -75,7 +75,12 @@ class ResponseDecoder
      */
     private function getCacheId(Request $request)
     {
-        $id = $request->getMethod() . $request->getUri();
-        return sha1(preg_replace('/[^A-Za-z0-9\.\- ]/', '', $id));
+        return sha1(
+            preg_replace(
+                '/[^A-Za-z0-9\.\- ]/',
+                '',
+                $request->getMethod().$request->getUri()
+            )
+        );
     }
 }

--- a/src/Service/Decoder/ResponseDecoder.php
+++ b/src/Service/Decoder/ResponseDecoder.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service\Decoder;
+
+use App\Service\Cache;
+use Http\Client\Exception\NetworkException;
+use Http\Client\HttpClient;
+use Nyholm\Psr7\Request;
+use Symfony\Component\Cache\Simple\FilesystemCache;
+
+class ResponseDecoder
+{
+    /**
+     * @var bool
+     */
+    private $cacheEndpoint;
+
+    /**
+     * @var HttpClient
+     */
+    private $client;
+
+    /**
+     * @var FilesystemCache
+     */
+    private $cache;
+
+    public function __construct(bool $cacheEndpoint, HttpClient $client, Cache $cache)
+    {
+        $this->cacheEndpoint = $cacheEndpoint;
+        $this->client = $client;
+        $this->cache = $cache();
+    }
+
+    /**
+     * @param Request $request
+     * @return array|mixed|\Psr\Http\Message\StreamInterface
+     * @throws \Http\Client\Exception
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     */
+    public function getDecodedResponse(Request $request)
+    {
+        try {
+            $response = $this->client->sendRequest($request);
+            $decodedResponse = json_decode($response->getBody(), true);
+
+            if(!in_array($response->getStatusCode(), range(200, 299))) {
+                if ($this->cacheEndpoint && $this->cache->has($this->getCacheId($request))) {
+                    return $this->cache->get($this->getCacheId($request));
+                }
+                return [];
+            }
+
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                $decodedResponse = $response->getBody();
+            }
+
+            if ($this->cacheEndpoint) {
+                $this->cache->set($this->getCacheId($request), $decodedResponse);
+            }
+
+            return $decodedResponse;
+        } catch (NetworkException $e) {
+            if ($this->cacheEndpoint && $this->cache->has($this->getCacheId($request))) {
+                return $this->cache->get($this->getCacheId($request));
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * @param Request $request
+     * @return string
+     */
+    private function getCacheId(Request $request)
+    {
+        $id = $request->getMethod() . $request->getUri();
+        return sha1(preg_replace('/[^A-Za-z0-9\.\- ]/', '', $id));
+    }
+}

--- a/tests/Service/Decoder/ResponseDecoderTest.php
+++ b/tests/Service/Decoder/ResponseDecoderTest.php
@@ -1,0 +1,171 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Service\Decoder;
+
+use App\Service\Cache;
+use App\Service\Decoder\ResponseDecoder;
+use Http\Client\Exception\NetworkException;
+use Http\Client\HttpClient;
+use Nyholm\Psr7\Request;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Cache\Simple\FilesystemCache;
+
+class ResponseDecoderTest extends TestCase
+{
+    /**
+     * @var HttpClient|\Prophecy\Prophecy\ObjectProphecy
+     */
+    private $client;
+
+    /**
+     * @var Cache|\Prophecy\Prophecy\ObjectProphecy
+     */
+    private $cache;
+
+    /**
+     * @var \Prophecy\Prophecy\ObjectProphecy|FilesystemCache
+     */
+    private $simpleCache;
+
+    protected function setUp()
+    {
+        $this->client = $this->prophesize(HttpClient::class);
+        $this->cache = $this->prophesize(Cache::class);
+        $this->simpleCache = $this->prophesize(FilesystemCache::class);
+        $this->cache->__invoke()->willReturn($this->simpleCache->reveal());
+    }
+
+    public function testGetDecodedResponse()
+    {
+        $decoder = new ResponseDecoder(false, $this->client->reveal(), $this->cache->reveal());
+
+        $request = new Request('GET', 'endpoint/data.json');
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->getStatusCode()->willReturn(200);
+        $response->getBody()->willReturn(json_encode(['json' => 'data']));
+
+        $this->client->sendRequest($request)->willReturn($response->reveal());
+
+        $this->assertSame(
+            ['json' => 'data'],
+            $decoder->getDecodedResponse($request)
+        );
+    }
+
+    public function testGetDecodedResponseEmptyOnRequestError()
+    {
+        $decoder = new ResponseDecoder(false, $this->client->reveal(), $this->cache->reveal());
+
+        $request = new Request('GET', 'endpoint/data.json');
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->getStatusCode()->willReturn(500);
+        $response->getBody()->willReturn('');
+
+        $this->client->sendRequest($request)->willReturn($response->reveal());
+
+        $this->assertSame(
+            [],
+            $decoder->getDecodedResponse($request)
+        );
+    }
+
+    public function testGetDecodedResponseFromCacheOnRequestError()
+    {
+        $decoder = new ResponseDecoder(true, $this->client->reveal(), $this->cache->reveal());
+
+        $request = new Request('GET', 'endpoint/data.json');
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->getStatusCode()->willReturn(500);
+        $response->getBody()->willReturn('');
+
+        $this->simpleCache->has('4429b090fd82239e188859ae626162e5e790b4db')->willReturn(true);
+        $this->simpleCache->get('4429b090fd82239e188859ae626162e5e790b4db')->willReturn(['json' => 'cache']);
+
+        $this->client->sendRequest($request)->willReturn($response->reveal());
+
+        $this->assertSame(
+            ['json' => 'cache'],
+            $decoder->getDecodedResponse($request)
+        );
+    }
+
+    public function testGetDecodedResponseCachesDataIfEnabled()
+    {
+        $decoder = new ResponseDecoder(true, $this->client->reveal(), $this->cache->reveal());
+
+        $request = new Request('GET', 'endpoint/data.json');
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->getStatusCode()->willReturn(200);
+        $response->getBody()->willReturn(json_encode(['json' => 'cache']));
+
+        $this->simpleCache->has('4429b090fd82239e188859ae626162e5e790b4db')->willReturn(false);
+        $this->simpleCache->set('4429b090fd82239e188859ae626162e5e790b4db', ['json' => 'cache'])->shouldBeCalledOnce();
+
+        $this->client->sendRequest($request)->willReturn($response->reveal());
+
+        $this->assertSame(
+            ['json' => 'cache'],
+            $decoder->getDecodedResponse($request)
+        );
+    }
+
+    public function testGetDecodedResponseFromCacheWhenNetworkFails()
+    {
+        $decoder = new ResponseDecoder(true, $this->client->reveal(), $this->cache->reveal());
+
+        $request = new Request('GET', 'endpoint/data.json');
+
+        $this->simpleCache->has('4429b090fd82239e188859ae626162e5e790b4db')->willReturn(true);
+        $this->simpleCache->get('4429b090fd82239e188859ae626162e5e790b4db')->willReturn(['json' => 'cache']);
+
+        $this->client->sendRequest($request)->willThrow(NetworkException::class);
+
+        $this->assertSame(
+            ['json' => 'cache'],
+            $decoder->getDecodedResponse($request)
+        );
+    }
+
+    /**
+     * @throws \Http\Client\Exception
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     * @expectedException \Http\Client\Exception\NetworkException
+     */
+    public function testGetDecodedResponseThrowsNetworkExceptionWhenClientFailsAndNoCachedVersion()
+    {
+        $decoder = new ResponseDecoder(true, $this->client->reveal(), $this->cache->reveal());
+        $request = new Request('GET', 'endpoint/data.json');
+
+        $this->simpleCache->has('4429b090fd82239e188859ae626162e5e790b4db')->willReturn(false);
+        $this->client->sendRequest($request)->willThrow(NetworkException::class);
+
+        $decoder->getDecodedResponse($request);
+    }
+
+    /**
+     * @todo this seems like a bug, we should not store in the cache invalid json? should we throw an error?
+     * @throws \Http\Client\Exception
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     */
+    public function testGetDecodedResponseReturnsBodyWhenJsonDecodingFails()
+    {
+        $decoder = new ResponseDecoder(true, $this->client->reveal(), $this->cache->reveal());
+
+        $request = new Request('GET', 'endpoint/data.json');
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->getStatusCode()->willReturn(200);
+        $response->getBody()->willReturn('{invalid_json');
+
+        $this->client->sendRequest($request)->willReturn($response->reveal());
+        $this->simpleCache->set('4429b090fd82239e188859ae626162e5e790b4db', '{invalid_json')->shouldBeCalledOnce();
+
+        $this->assertSame(
+            '{invalid_json',
+            $decoder->getDecodedResponse($request)
+        );
+
+        $this->markAsRisky();
+    }
+}

--- a/tests/Service/OfficialEndpointProxyTest.php
+++ b/tests/Service/OfficialEndpointProxyTest.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Service\Decoder\ResponseDecoder;
+use App\Service\OfficialEndpointProxy;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+
+class OfficialEndpointProxyTest extends TestCase
+{
+    /**
+     * @var OfficialEndpointProxy
+     */
+    private $proxy;
+
+    /**
+     * @var ResponseDecoder|ObjectProphecy
+     */
+    private $decoder;
+
+    protected function setUp()
+    {
+        $this->decoder = $this->prophesize(ResponseDecoder::class);
+
+        $this->proxy = new OfficialEndpointProxy(
+            'official_endpoint/',
+            $this->decoder->reveal()
+        );
+    }
+
+    public function testGetAliases()
+    {
+        $this
+            ->decoder
+            ->getDecodedResponse(
+                Argument::allOf(
+                    Argument::which('getMethod', 'GET'),
+                    Argument::which('getUri', 'official_endpoint/aliases.json')
+                )
+            )
+            ->willReturn('decoded response');
+
+        $this->assertSame('decoded response', $this->proxy->getAliases());
+    }
+
+    public function testGetVersions()
+    {
+        $this
+            ->decoder
+            ->getDecodedResponse(
+                Argument::allOf(
+                    Argument::which('getMethod', 'GET'),
+                    Argument::which('getUri', 'official_endpoint/versions.json')
+                )
+            )
+            ->willReturn('decoded response');
+
+        $this->assertSame('decoded response', $this->proxy->getVersions());
+    }
+
+    public function testGetPackages()
+    {
+        $this
+            ->decoder
+            ->getDecodedResponse(
+                Argument::allOf(
+                    Argument::which('getMethod', 'GET'),
+                    Argument::which('getUri', 'official_endpoint/p/package_name')
+                )
+            )
+            ->willReturn('decoded response');
+
+        $this->assertSame('decoded response', $this->proxy->getPackages('package_name'));
+    }
+}


### PR DESCRIPTION
- Added test for methods under official endpoint proxy
- Moved decoder logic into a class (easier to test)
- Add test for response decoder