### PR TITLE
Fix doc to not quote boolean

### DIFF
--- a/docs/topics/setup.md
+++ b/docs/topics/setup.md
@@ -33,7 +33,7 @@ Make sure to allow connections over http to composer (if using localhost) by add
     {
         ...
         "config": {
-            "secure-http": "false"
+            "secure-http": false
         }
     }
     


### PR DESCRIPTION
As shown in the documentation the value of "secure-http" should be a boolean and does not have to be quoted. (https://getcomposer.org/doc/06-config.md#secure-http)

This does not cause an error like 2016 (https://github.com/composer/composer/issues/5105) as composer is more failure tolerant but could be changed to follow best practice.