### PR TITLE
Fixed executable determination

### DIFF
--- a/src/Service/Compiler/PackagesCompiler.php
+++ b/src/Service/Compiler/PackagesCompiler.php
@@ -125,7 +125,7 @@ class PackagesCompiler
             }
             $files[$file->getRelativePathName()] = [
                 'contents' => $file->getContents(),
-                'executable' => is_executable($recipe->getLocalPath().$file->getRelativePathName()),
+                'executable' => is_executable($file->getPathname()),
             ];
         }
 


### PR DESCRIPTION
I noticed that when copying files from the recipe that have the executable bit set, this bit was lost after copying. The cause was that the filename used for determining whether the executable flag was set was a concatenation of the recipe path and the relative filename. However, there was no directory separator, so the path to the file was always invalid and thus the executable flag was always set to `false`.

I changed the code to use the absolute path to the file instead of a concatenation of the recipe path and the relative path to the file.