### PR TITLE
Bump flex to ^1.17, v1.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "symfony/dotenv": "^4",
         "symfony/filesystem": "^4",
         "symfony/finder": "^4",
-        "symfony/flex": "^1.13",
+        "symfony/flex": "^1.17",
         "symfony/framework-bundle": "^4",
         "symfony/monolog-bundle": "^3.5",
         "symfony/twig-bundle": "^4",


### PR DESCRIPTION
https://symfony.com/blog/the-old-flex-infrastructure-is-shutting-down